### PR TITLE
Add Dockerized film rating app with MongoDB API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+films
+.git

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/app.js
+++ b/app.js
@@ -1,41 +1,10 @@
-const createError = require('http-errors');
 const express = require('express');
 const path = require('path');
-const cookieParser = require('cookie-parser');
 const logger = require('morgan');
-
-const indexRouter = require('./routes/index');
-const usersRouter = require('./routes/users');
 
 const app = express();
 
-// view engine setup
-app.set('views', path.join(__dirname, 'views'));
-app.set('view engine', 'pug');
-
 app.use(logger('dev'));
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
-app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
-
-app.use('/', indexRouter);
-app.use('/users', usersRouter);
-
-// catch 404 and forward to error handler
-app.use(function(req, res, next) {
-  next(createError(404));
-});
-
-// error handler
-app.use(function(err, req, res, next) {
-  // set locals, only providing error in development
-  res.locals.message = err.message;
-  res.locals.error = req.app.get('env') === 'development' ? err : {};
-
-  // render the error page
-  res.status(err.status || 500);
-  res.render('error');
-});
 
 module.exports = app;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3'
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+    depends_on:
+      - films
+    expose:
+      - "3000"
+  films:
+    build:
+      context: ./films
+    environment:
+      - MONGO_URL=mongodb://mongo:27017/filmsdb
+    depends_on:
+      - mongo
+    expose:
+      - "3000"
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./public:/srv/www/static:ro
+    depends_on:
+      - web
+      - films

--- a/films/.dockerignore
+++ b/films/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/films/Dockerfile
+++ b/films/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/films/package.json
+++ b/films/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "films",
+  "version": "1.0.0",
+  "description": "Film ratings API",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "mongoose": "^7.6.1"
+  }
+}

--- a/films/server.js
+++ b/films/server.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const mongoose = require('mongoose');
+
+const app = express();
+app.use(express.json());
+
+const mongoUrl = process.env.MONGO_URL || 'mongodb://mongo:27017/filmsdb';
+mongoose.connect(mongoUrl);
+
+const FilmSchema = new mongoose.Schema({
+  title: { type: String, required: true },
+  rating: { type: Number, required: true }
+});
+
+const Film = mongoose.model('Film', FilmSchema);
+
+app.get('/api/v1/films', async (req, res) => {
+  try {
+    const films = await Film.find().sort({ _id: 1 });
+    res.json(films);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+app.post('/api/v1/films', async (req, res) => {
+  const { title, rating } = req.body;
+  if (!title) {
+    return res.status(400).json({ message: 'Title is required' });
+  }
+  if (rating === undefined || rating === null || rating === '') {
+    return res.status(400).json({ message: 'Rating is required' });
+  }
+  const numRating = Number(rating);
+  if (isNaN(numRating) || numRating < 1 || numRating > 10) {
+    return res.status(400).json({ message: 'Rating must be between 1 and 10' });
+  }
+
+  try {
+    const film = new Film({ title, rating: numRating });
+    await film.save();
+    res.status(201).json({ message: 'Film added successfully' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Films service listening on port ${port}`);
+});

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,13 @@
+server {
+  listen 8080;
+  root /srv/www/static;
+  location / {
+    try_files $uri $uri/ @web;
+  }
+  location @web {
+    proxy_pass http://web:3000;
+  }
+  location /api/v1/films {
+    proxy_pass http://films:3000;
+  }
+}

--- a/public/films.js
+++ b/public/films.js
@@ -1,39 +1,58 @@
 // public/films.js
 
 const API = (function() {
-    let films = [];
-
-    function clearSuccessMessage() {
+    function clearMessage() {
         const msg = document.getElementById('successMessage');
         msg.textContent = '';
         msg.classList.add('hidden');
     }
 
+    function showMessage(message, isError = false) {
+        const msg = document.getElementById('successMessage');
+        msg.textContent = message;
+        msg.className = isError ? 'error' : 'success';
+        setTimeout(clearMessage, 2000);
+    }
+
     function createFilm() {
-        const input = document.getElementById('filmTitle');
+        const titleInput = document.getElementById('filmTitle');
         const ratingInput = document.getElementById('filmRating');
-        const title = input.value.trim();
-        const rating = parseInt(ratingInput.value, 10);
-        clearSuccessMessage();
+        const title = titleInput.value.trim();
+        const ratingRaw = ratingInput.value.trim();
+        clearMessage();
 
         if (title.length === 0) {
-            showSuccess('Film title cannot be empty.', true);
+            showMessage('Title cannot be empty.', true);
             return false;
         }
-
+        if (ratingRaw.length === 0) {
+            showMessage('Rating cannot be empty.', true);
+            return false;
+        }
+        const rating = parseInt(ratingRaw, 10);
         if (isNaN(rating) || rating < 1 || rating > 10) {
-            showSuccess('Please provide a rating between 1 and 10.', true);
+            showMessage('Please provide a rating between 1 and 10.', true);
             return false;
         }
 
-        films.push({ title: title, rating: rating });
-        input.value = '';
-        ratingInput.value = '10';
-        showSuccess('Film added successfully!');
+        fetch('/api/v1/films', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ title, rating })
+        })
+            .then(res => {
+                if (!res.ok) {
+                    return res.json().then(data => Promise.reject(data.message || 'Failed to add film.'));
+                }
+                return res.json();
+            })
+            .then(() => {
+                titleInput.value = '';
+                ratingInput.value = '';
+                showMessage('Film added successfully!');
+            })
+            .catch(err => showMessage(err, true));
 
-        if (films.length === 0) {
-            document.getElementById('filmsTable').classList.add('hidden');
-        }
         return false;
     }
 
@@ -41,32 +60,29 @@ const API = (function() {
         const table = document.getElementById('filmsTable');
         const tbody = table.querySelector('tbody');
         tbody.innerHTML = '';
-        clearSuccessMessage();
+        clearMessage();
 
-        if (films.length === 0) {
-            table.classList.add('hidden');
-            return false;
-        }
+        fetch('/api/v1/films')
+            .then(res => res.json())
+            .then(data => {
+                if (!Array.isArray(data) || data.length === 0) {
+                    table.classList.add('hidden');
+                    return;
+                }
+                data.forEach((film, idx) => {
+                    const row = document.createElement('tr');
+                    row.innerHTML = `
+                        <td>${idx + 1}</td>
+                        <td>${film.title}</td>
+                        <td><span class="badge">${film.rating}/10</span></td>
+                    `;
+                    tbody.appendChild(row);
+                });
+                table.classList.remove('hidden');
+            })
+            .catch(() => showMessage('Failed to retrieve films.', true));
 
-        films.forEach((film, idx) => {
-            const row = document.createElement('tr');
-            row.innerHTML = `
-                <td>${idx + 1}</td>
-                <td>${film.title}</td>
-                <td><span class="badge">${film.rating}/10</span></td>
-            `;
-            tbody.appendChild(row);
-        });
-
-        table.classList.remove('hidden');
         return false;
-    }
-
-    function showSuccess(message, isError = false) {
-        const msg = document.getElementById('successMessage');
-        msg.textContent = message;
-        msg.className = isError ? 'error' : 'success';
-        setTimeout(clearSuccessMessage, 2000);
     }
 
     return {

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Film Ratings</title>
     <link rel="stylesheet" href="stylesheets/style.css">
     <script type="text/javascript" src="./films.js" defer></script>
@@ -24,7 +25,7 @@
                 min="1"
                 max="10"
                 step="1"
-                value="10"
+                placeholder="Rating"
                 required
                 style="width:80px;"
             >

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -121,3 +121,19 @@ button:hover, button:focus {
 .hidden {
     display: none !important;
 }
+
+@media (max-width: 480px) {
+    .container {
+        margin: 20px auto;
+        padding: 1rem;
+    }
+    form {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    input[type="text"],
+    input[type="number"],
+    button {
+        width: 100%;
+    }
+}

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,9 +1,0 @@
-var express = require('express');
-var router = express.Router();
-
-/* GET home page. */
-router.get('/', function(req, res, next) {
-  res.render('index', { title: 'Express' });
-});
-
-module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,9 +1,0 @@
-var express = require('express');
-var router = express.Router();
-
-/* GET users listing. */
-router.get('/', function(req, res, next) {
-  res.send('respond with a resource');
-});
-
-module.exports = router;

--- a/views/error.pug
+++ b/views/error.pug
@@ -1,6 +1,0 @@
-extends layout
-
-block content
-  h1= message
-  h2= error.status
-  pre= error.stack

--- a/views/index.pug
+++ b/views/index.pug
@@ -1,5 +1,0 @@
-extends layout
-
-block content
-  h1= title
-  p Welcome to Express

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -1,6 +1,0 @@
-doctype html
-html
-  head
-    title= title
-  body
-    block content


### PR DESCRIPTION
## Summary
- serve static client via Express with updated mobile-friendly index and styles
- add frontend logic to validate ratings and call `/api/v1/films`
- implement MongoDB-backed film API with rating validation
- provide Docker setup with Nginx proxy and separate web and films services

## Testing
- `npm test` *(fails: Missing script "test")*
- `(cd films && npm test)` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68abd06b07888325a9f91ea69b49c7cd