### PR TITLE
Implement dedicated auth pages and improve JWT security

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     build: ./films
     environment:
       - MONGO_URL=mongodb://mongo:27017/filmsdb
+      - JWT_SECRET=change_me
     ports:
       - "3001:3000"
     depends_on:

--- a/films/package-lock.json
+++ b/films/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "bcryptjs": "^3.0.2",
         "express": "^4.19.2",
+        "helmet": "^7.0.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.6.1"
       }
@@ -463,6 +464,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/films/package.json
+++ b/films/package.json
@@ -10,6 +10,7 @@
     "bcryptjs": "^3.0.2",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^7.6.1"
+    "mongoose": "^7.6.1",
+    "helmet": "^7.0.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -10,19 +10,7 @@
 <body>
     <div class="container">
         <h1>Film Ratings Manager</h1>
-        <form id="loginForm" onsubmit="return API.login()">
-            <input type="text" id="loginUsername" placeholder="Username" required autocomplete="off">
-            <input type="password" id="loginPassword" placeholder="Password" required>
-            <button type="submit">Login</button>
-        </form>
-
-        <form id="registerForm" onsubmit="return API.register()">
-            <input type="text" id="regName" placeholder="Name" required autocomplete="off">
-            <input type="text" id="regUsername" placeholder="Username" required autocomplete="off">
-            <input type="password" id="regPassword" placeholder="Password" required>
-            <button type="submit">Register</button>
-        </form>
-
+        <button id="logoutBtn" onclick="API.logout()">Logout</button>
         <div id="successMessage" class="hidden"></div>
 
         <form id="filmForm" onsubmit="return API.createFilm()">

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Login</title>
+    <link rel="stylesheet" href="stylesheets/style.css">
+    <script type="text/javascript" src="./login.js" defer></script>
+</head>
+<body>
+    <div class="container">
+        <h1>Login</h1>
+        <form id="loginForm" onsubmit="return Auth.login()">
+            <input type="text" id="loginUsername" placeholder="Username" required autocomplete="off">
+            <input type="password" id="loginPassword" placeholder="Password" required>
+            <button type="submit">Login</button>
+        </form>
+        <p style="text-align:center;">No account? <a href="register.html">Register</a></p>
+        <div id="successMessage" class="hidden"></div>
+    </div>
+</body>
+</html>

--- a/public/login.js
+++ b/public/login.js
@@ -1,0 +1,54 @@
+const Auth = (() => {
+    const API_BASE = '/api/v1';
+
+    function clearMessage() {
+        const msg = document.getElementById('successMessage');
+        msg.textContent = '';
+        msg.classList.add('hidden');
+    }
+
+    function showMessage(message, isError = false) {
+        const msg = document.getElementById('successMessage');
+        msg.textContent = message;
+        msg.className = isError ? 'error' : 'success';
+        setTimeout(clearMessage, 2000);
+    }
+
+    async function handleResponse(res) {
+        const contentType = res.headers.get('content-type') || '';
+        const data = contentType.includes('application/json') ? await res.json() : await res.text();
+        if (!res.ok) {
+            throw new Error(data.message || data || 'Request failed');
+        }
+        return data;
+    }
+
+    function login() {
+        const username = document.getElementById('loginUsername').value.trim();
+        const password = document.getElementById('loginPassword').value.trim();
+        clearMessage();
+        fetch(`${API_BASE}/login`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username, password })
+        })
+            .then(handleResponse)
+            .then(data => {
+                localStorage.setItem('token', data.token);
+                showMessage('Logged in successfully');
+                setTimeout(() => {
+                    window.location.href = 'index.html';
+                }, 500);
+            })
+            .catch(err => showMessage(err.message || err, true));
+        return false;
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        if (localStorage.getItem('token')) {
+            window.location.href = 'index.html';
+        }
+    });
+
+    return { login };
+})();

--- a/public/register.html
+++ b/public/register.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Register</title>
+    <link rel="stylesheet" href="stylesheets/style.css">
+    <script type="text/javascript" src="./register.js" defer></script>
+</head>
+<body>
+    <div class="container">
+        <h1>Register</h1>
+        <form id="registerForm" onsubmit="return Auth.register()">
+            <input type="text" id="regName" placeholder="Name" required autocomplete="off">
+            <input type="text" id="regUsername" placeholder="Username" required autocomplete="off">
+            <input type="password" id="regPassword" placeholder="Password" required>
+            <button type="submit">Register</button>
+        </form>
+        <p style="text-align:center;">Already have an account? <a href="login.html">Login</a></p>
+        <div id="successMessage" class="hidden"></div>
+    </div>
+</body>
+</html>

--- a/public/register.js
+++ b/public/register.js
@@ -1,0 +1,54 @@
+const Auth = (() => {
+    const API_BASE = '/api/v1';
+
+    function clearMessage() {
+        const msg = document.getElementById('successMessage');
+        msg.textContent = '';
+        msg.classList.add('hidden');
+    }
+
+    function showMessage(message, isError = false) {
+        const msg = document.getElementById('successMessage');
+        msg.textContent = message;
+        msg.className = isError ? 'error' : 'success';
+        setTimeout(clearMessage, 2000);
+    }
+
+    async function handleResponse(res) {
+        const contentType = res.headers.get('content-type') || '';
+        const data = contentType.includes('application/json') ? await res.json() : await res.text();
+        if (!res.ok) {
+            throw new Error(data.message || data || 'Request failed');
+        }
+        return data;
+    }
+
+    function register() {
+        const name = document.getElementById('regName').value.trim();
+        const username = document.getElementById('regUsername').value.trim();
+        const password = document.getElementById('regPassword').value.trim();
+        clearMessage();
+        fetch(`${API_BASE}/register`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, username, password })
+        })
+            .then(handleResponse)
+            .then(() => {
+                showMessage('User registered successfully');
+                setTimeout(() => {
+                    window.location.href = 'login.html';
+                }, 500);
+            })
+            .catch(err => showMessage(err.message || err, true));
+        return false;
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        if (localStorage.getItem('token')) {
+            window.location.href = 'index.html';
+        }
+    });
+
+    return { register };
+})();


### PR DESCRIPTION
## Summary
- add standalone login and registration pages that redirect appropriately
- update film page to require auth, support logout, and use relative API paths
- secure API with helmet, expiring JWT tokens, and env-based secret

## Testing
- `npm test` (fails: Missing script: "test")
- `cd films && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68abdfb1a634832593115374cc62b77b