### PR TITLE
Fix nginx API proxy path

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -8,6 +8,6 @@ server {
     proxy_pass http://web:3000;
   }
   location /api/v1/ {
-    proxy_pass http://films:3000/;
+    proxy_pass http://films:3000;
   }
 }


### PR DESCRIPTION
## Summary
- ensure `/api/v1` requests keep their full path when proxied to the films service by removing extra slash in `default.conf`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abe8fb81488325a0e04680306b3bff