### PR TITLE
feat: add user-specific film ratings and clear option

### DIFF
--- a/public/films.js
+++ b/public/films.js
@@ -81,7 +81,11 @@ const API = (function() {
         tbody.innerHTML = '';
         clearMessage();
 
-        fetch(API_URL)
+        fetch(API_URL, {
+            headers: {
+                'Authorization': `Bearer ${jwtToken}`
+            }
+        })
             .then(handleResponse)
             .then(data => {
                 data.forEach((film, idx) => {
@@ -103,6 +107,28 @@ const API = (function() {
         return false;
     }
 
+    function clearFilms() {
+        const table = document.getElementById('filmsTable');
+        const tbody = table.querySelector('tbody');
+        clearMessage();
+
+        fetch(API_URL, {
+            method: 'DELETE',
+            headers: {
+                'Authorization': `Bearer ${jwtToken}`
+            }
+        })
+            .then(handleResponse)
+            .then(() => {
+                tbody.innerHTML = '';
+                table.classList.add('hidden');
+                showMessage('Films cleared successfully');
+            })
+            .catch(err => showMessage(err.message || err, true));
+
+        return false;
+    }
+
     function logout() {
         localStorage.removeItem('token');
         jwtToken = '';
@@ -112,6 +138,7 @@ const API = (function() {
     return {
         createFilm,
         getFilms,
+        clearFilms,
         logout
     };
 })();

--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,10 @@
             </thead>
             <tbody></tbody>
         </table>
+
+        <form id="clearFilmsForm" onsubmit="return API.clearFilms()">
+            <button type="submit">Clear Films</button>
+        </form>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- track film ratings per user in the API
- allow users to wipe their own ratings with a clear films button
- secure film retrieval so users only see their data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd films && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac60250e388325b8403fbd65edcf0c