### PR TITLE
Add password visibility toggles to auth forms

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -12,7 +12,10 @@
         <h1>Login</h1>
         <form id="loginForm" onsubmit="return Auth.login()">
             <input type="text" id="loginUsername" placeholder="Username" required autocomplete="off">
-            <input type="password" id="loginPassword" placeholder="Password" required>
+            <div class="password-container">
+                <input type="password" id="loginPassword" placeholder="Password" required>
+                <span id="toggleLoginPassword" class="password-toggle">👁️</span>
+            </div>
             <button type="submit">Login</button>
         </form>
         <p>No account? <a href="register.html">Register</a></p>

--- a/public/login.js
+++ b/public/login.js
@@ -48,6 +48,15 @@ const Auth = (() => {
         if (localStorage.getItem('token')) {
             window.location.href = 'index.html';
         }
+        const toggle = document.getElementById('toggleLoginPassword');
+        const password = document.getElementById('loginPassword');
+        if (toggle && password) {
+            toggle.addEventListener('click', () => {
+                const type = password.getAttribute('type') === 'password' ? 'text' : 'password';
+                password.setAttribute('type', type);
+                toggle.textContent = type === 'password' ? '👁️' : '🙈';
+            });
+        }
     });
 
     return { login };

--- a/public/register.html
+++ b/public/register.html
@@ -13,7 +13,10 @@
         <form id="registerForm" onsubmit="return Auth.register()">
             <input type="text" id="regName" placeholder="Name" required autocomplete="off">
             <input type="text" id="regUsername" placeholder="Username" required autocomplete="off">
-            <input type="password" id="regPassword" placeholder="Password" required>
+            <div class="password-container">
+                <input type="password" id="regPassword" placeholder="Password" required>
+                <span id="toggleRegPassword" class="password-toggle">👁️</span>
+            </div>
             <button type="submit">Register</button>
         </form>
         <p>Already have an account? <a href="login.html">Login</a></p>

--- a/public/register.js
+++ b/public/register.js
@@ -48,6 +48,15 @@ const Auth = (() => {
         if (localStorage.getItem('token')) {
             window.location.href = 'index.html';
         }
+        const toggle = document.getElementById('toggleRegPassword');
+        const password = document.getElementById('regPassword');
+        if (toggle && password) {
+            toggle.addEventListener('click', () => {
+                const type = password.getAttribute('type') === 'password' ? 'text' : 'password';
+                password.setAttribute('type', type);
+                toggle.textContent = type === 'password' ? '👁️' : '🙈';
+            });
+        }
     });
 
     return { register };

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -174,6 +174,23 @@ body.auth-page {
     display: none !important;
 }
 
+.password-container {
+    position: relative;
+}
+
+.password-container input {
+    padding-right: 2.5rem;
+}
+
+.password-toggle {
+    position: absolute;
+    top: 50%;
+    right: 10px;
+    transform: translateY(-50%);
+    cursor: pointer;
+    user-select: none;
+}
+
 #logoutBtn {
     position: fixed;
     top: 20px;


### PR DESCRIPTION
## Summary
- allow login and registration password fields to be toggled visible
- style password toggle icon

## Testing
- npm test (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_68ac606bbe308325a7cbbc77d25432f8