### PR TITLE
feat: add mobile client and rating update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,36 @@ all services are available through a single port.
    docker-compose down
    ```
 
+## Access from other devices
+To use the site or API from phones or other computers on your local network:
+
+1. Find your computer's local IP address.
+   - Windows: run `ipconfig` and look for the IPv4 address.
+   - macOS/Linux: run `ifconfig` or `ip addr`.
+2. Start the project as described above.
+3. From the other device, browse to `http://YOUR_IP:8080` replacing `YOUR_IP` with the address from step 1.
+4. If the films service is run separately, set the environment variable `FILMS_SERVICE_URL` before starting the web app:
+   ```bash
+   export FILMS_SERVICE_URL=http://YOUR_IP:3001
+   ```
+
+The API base URL for mobile apps should also use the IP address, e.g. `http://YOUR_IP:8080/api/v1`.
+
+## Mobile App
+A minimal React Native client is provided in the `mobile/` directory. It allows logging in,
+listing films, adding new films and updating ratings.
+
+### Running the app
+1. Install [Node.js](https://nodejs.org/) and [Expo](https://docs.expo.dev/get-started/installation/).
+2. In the `mobile` folder run:
+   ```bash
+   npm install
+   npm start
+   ```
+3. When prompted, open the app on your mobile device using the Expo Go app or an emulator.
+4. Edit `mobile/App.js` and replace `YOUR_IP` in `API_BASE` with the IP address of your computer so the app can reach the API.
+
+
 ## Project Structure
 - `Dockerfile` – Docker setup for the web front end
 - `films/` – Films API service (includes its own `Dockerfile`)

--- a/bin/www
+++ b/bin/www
@@ -25,7 +25,7 @@ var server = http.createServer(app);
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port);
+server.listen(port, '0.0.0.0');
 server.on('error', onError);
 server.on('listening', onListening);
 

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,118 @@
+import React, { useState, useEffect } from 'react';
+import { SafeAreaView, View, Text, TextInput, Button, FlatList, Alert } from 'react-native';
+
+const API_BASE = 'http://YOUR_IP:8080/api/v1';
+
+export default function App() {
+  const [token, setToken] = useState('');
+  const [films, setFilms] = useState([]);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [title, setTitle] = useState('');
+  const [rating, setRating] = useState('');
+
+  const handleResponse = async res => {
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || 'Request failed');
+    return data;
+  };
+
+  const loadFilms = async () => {
+    try {
+      const headers = token ? { Authorization: `Bearer ${token}` } : {};
+      const res = await fetch(`${API_BASE}/films`, { headers });
+      const data = await handleResponse(res);
+      setFilms(data);
+    } catch (err) {
+      Alert.alert('Error', err.message);
+    }
+  };
+
+  useEffect(() => { loadFilms(); }, [token]);
+
+  const login = async () => {
+    try {
+      const res = await fetch(`${API_BASE}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      const data = await handleResponse(res);
+      setToken(data.token);
+      Alert.alert('Success', 'Logged in');
+    } catch (err) {
+      Alert.alert('Error', err.message);
+    }
+  };
+
+  const addFilm = async () => {
+    if (!token) {
+      Alert.alert('Login required');
+      return;
+    }
+    try {
+      const res = await fetch(`${API_BASE}/films`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ title, rating })
+      });
+      await handleResponse(res);
+      setTitle('');
+      setRating('');
+      loadFilms();
+    } catch (err) {
+      Alert.alert('Error', err.message);
+    }
+  };
+
+  const updateRating = async id => {
+    if (!token) {
+      Alert.alert('Login required');
+      return;
+    }
+    const newRating = prompt('New rating 1-10');
+    if (newRating === null) return;
+    try {
+      const res = await fetch(`${API_BASE}/films/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ rating: newRating })
+      });
+      await handleResponse(res);
+      loadFilms();
+    } catch (err) {
+      Alert.alert('Error', err.message);
+    }
+  };
+
+  return (
+    <SafeAreaView style={{ flex: 1, padding: 20 }}>
+      <View style={{ marginBottom: 20 }}>
+        <Text>Username</Text>
+        <TextInput value={username} onChangeText={setUsername} autoCapitalize='none' style={{ borderWidth:1, marginBottom:8 }} />
+        <Text>Password</Text>
+        <TextInput value={password} onChangeText={setPassword} secureTextEntry style={{ borderWidth:1, marginBottom:8 }} />
+        <Button title="Login" onPress={login} />
+      </View>
+
+      <View style={{ marginBottom: 20 }}>
+        <Text>Title</Text>
+        <TextInput value={title} onChangeText={setTitle} style={{ borderWidth:1, marginBottom:8 }} />
+        <Text>Rating</Text>
+        <TextInput value={rating} onChangeText={setRating} keyboardType='numeric' style={{ borderWidth:1, marginBottom:8 }} />
+        <Button title="Add Film" onPress={addFilm} />
+      </View>
+
+      <FlatList
+        data={films}
+        keyExtractor={item => item._id}
+        renderItem={({ item }) => (
+          <View style={{ marginBottom: 10 }}>
+            <Text>{item.title} - {item.rating}/10</Text>
+            {token ? <Button title="Edit" onPress={() => updateRating(item._id)} /> : null}
+          </View>
+        )}
+      />
+    </SafeAreaView>
+  );
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "film-mobile",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "expo-status-bar": "~1.11.1",
+    "react": "18.2.0",
+    "react-native": "0.74.0"
+  }
+}

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -78,6 +78,11 @@ button:active {
     box-shadow: 0 0 0 #000;
 }
 
+.edit-btn {
+    padding: 0.2rem 0.5rem;
+    margin-left: 5px;
+}
+
 #filmsTable {
     width: 100%;
     border-collapse: collapse;
@@ -196,6 +201,29 @@ body.auth-page {
     top: 20px;
     right: 20px;
     z-index: 1000;
+}
+
+@media (max-width: 600px) {
+    .container {
+        margin: 20px auto;
+        padding: 1rem;
+        max-width: 100%;
+    }
+    form {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    input[type="number"] {
+        width: 100%;
+    }
+    #filmsTable th, #filmsTable td {
+        padding: 0.5rem;
+        font-size: 0.9rem;
+    }
+    #logoutBtn {
+        top: 10px;
+        right: 10px;
+    }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
- allow unauthenticated film listing with optional auth and add PUT endpoint to update ratings
- make web UI responsive and add edit controls for film ratings
- document exposing services on the network and include simple React Native mobile app

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd films && npm test` *(fails: Missing script: "test")*
- `cd mobile && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac641daf50832589edb106124453e1