### PR TITLE
Expose API object globally for inline handlers

### DIFF
--- a/public/films.js
+++ b/public/films.js
@@ -1,6 +1,8 @@
 // public/films.js
 
-const API = (function() {
+// Expose the API helper on the global window object so that inline
+// event handlers in the HTML can access its methods.
+window.API = (function() {
     function clearMessage() {
         const msg = document.getElementById('successMessage');
         msg.textContent = '';


### PR DESCRIPTION
## Summary
- fix `API is not defined` errors by attaching API helper to `window`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac84099fc88325860e1272f53a91b5