### PR TITLE
Fix films listing template string causing API undefined

### DIFF
--- a/public/films.js
+++ b/public/films.js
@@ -98,9 +98,7 @@ window.API = (function() {
                     row.innerHTML = `
                         <td>${idx + 1}</td>
                         <td>${film.title}</td>
-                        <td><span class="badge">${film.rating}/10</span>$
-                            {jwtToken ? ` <button class="edit-btn" data-id="${film._id}" data-rating="${film.rating}">Edit</button>` : ''}
-                        </td>
+                        <td><span class="badge">${film.rating}/10</span>${jwtToken ? ` <button class="edit-btn" data-id="${film._id}" data-rating="${film.rating}">Edit</button>` : ''}</td>
                     `;
                     tbody.appendChild(row);
                 });


### PR DESCRIPTION
## Summary
- fix template string in films.js to properly inject Edit button without syntax error

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac8a140dc08325bc0b5b1cf1b4a1a8