### PR TITLE
Fix mobile app startup by registering root component

### DIFF
--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "film-mobile",
   "version": "1.0.0",
-  "main": "App.js",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",


### PR DESCRIPTION
## Summary
- register root component with Expo
- point mobile package entry to new index.js

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68aca66246508325967ddb28c5091ea2