### PR TITLE
fix: ensure Android bundle succeeds

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -5,12 +5,16 @@
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",
-    "ios": "expo run:ios"
+    "ios": "expo run:ios",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "expo": "^50.0.0",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
     "react-native": "0.74.0"
+  },
+  "devDependencies": {
+    "patch-package": "^8.0.0"
   }
 }

--- a/mobile/patches/react-native+0.74.0.patch
+++ b/mobile/patches/react-native+0.74.0.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/react-native/src/private/specs/components/DebuggingOverlayNativeComponent.js b/node_modules/react-native/src/private/specs/components/DebuggingOverlayNativeComponent.js
+index 1234567..89abcde 100644
+--- a/node_modules/react-native/src/private/specs/components/DebuggingOverlayNativeComponent.js
++++ b/node_modules/react-native/src/private/specs/components/DebuggingOverlayNativeComponent.js
+@@
+ interface NativeCommands {
+   +highlightTraceUpdates: (
+     viewRef: React.ElementRef<DebuggingOverlayNativeComponentType>,
+-    updates: $ReadOnlyArray<TraceUpdate>,
++    updates: ReadonlyArray<TraceUpdate>,
+   ) => void;
+   +highlightElements: (
+     viewRef: React.ElementRef<DebuggingOverlayNativeComponentType>,
+-    elements: $ReadOnlyArray<ElementRectangle>,
++    elements: ReadonlyArray<ElementRectangle>,
+   ) => void;
+   +clearElementsHighlights: (
+     viewRef: React.ElementRef<DebuggingOverlayNativeComponentType>,
+   ) => void;
+ }


### PR DESCRIPTION
## Summary
- patch DebuggingOverlayNativeComponent to avoid unsupported `$ReadOnlyArray` type
- run `patch-package` on install

## Testing
- `npm test` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_68acb25fec8483258d4267ba0fba613c