### PR TITLE
Handle missing NativeUnimoduleProxy

### DIFF
--- a/mobile/patches/expo-modules-core+1.11.14.patch
+++ b/mobile/patches/expo-modules-core+1.11.14.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/expo-modules-core/build/NativeModulesProxy.native.js b/node_modules/expo-modules-core/build/NativeModulesProxy.native.js
+index 984dfa3..9743bd2 100644
+--- a/node_modules/expo-modules-core/build/NativeModulesProxy.native.js
++++ b/node_modules/expo-modules-core/build/NativeModulesProxy.native.js
+@@ -1,5 +1,12 @@
+ import { NativeModules } from 'react-native';
+-const LegacyNativeProxy = NativeModules.NativeUnimoduleProxy;
++let LegacyNativeProxy;
++try {
++    LegacyNativeProxy = NativeModules.NativeUnimoduleProxy;
++}
++catch (e) {
++    console.warn('Failed to load NativeUnimoduleProxy', e);
++    LegacyNativeProxy = null;
++}
+ // Fixes `cannot find name 'global'.` in tests
+ // @ts-ignore
+ const ExpoNativeProxy = global.expo?.modules?.NativeModulesProxy;
+diff --git a/node_modules/expo-modules-core/src/NativeModulesProxy.native.ts b/node_modules/expo-modules-core/src/NativeModulesProxy.native.ts
+index f45d752..42c1629 100644
+--- a/node_modules/expo-modules-core/src/NativeModulesProxy.native.ts
++++ b/node_modules/expo-modules-core/src/NativeModulesProxy.native.ts
+@@ -2,7 +2,13 @@ import { NativeModules } from 'react-native';
+ 
+ import { ProxyNativeModule } from './NativeModulesProxy.types';
+ 
+-const LegacyNativeProxy = NativeModules.NativeUnimoduleProxy;
++let LegacyNativeProxy: any;
++try {
++  LegacyNativeProxy = (NativeModules as any).NativeUnimoduleProxy;
++} catch (e) {
++  console.warn('Failed to load NativeUnimoduleProxy', e);
++  LegacyNativeProxy = null;
++}
+ // Fixes `cannot find name 'global'.` in tests
+ // @ts-ignore
+ const ExpoNativeProxy = global.expo?.modules?.NativeModulesProxy;


### PR DESCRIPTION
## Summary
- avoid crash when NativeUnimoduleProxy fails by safely handling its absence

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd mobile && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ae09ec48188325a1b410f06893ab6a