### PR TITLE
feat: add film deletion endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ all services are available through a single port.
    ```
 3. Open your browser to [http://localhost:8080](http://localhost:8080) to use the web interface.
    - API calls are available via [http://localhost:8080/api/v1/films](http://localhost:8080/api/v1/films)
+   - Delete a specific film by sending a `DELETE` request to `/api/v1/films/:id` with a valid token
    - The web service is also exposed on port `3000` and the films API on port `3001` for direct access.
 4. When you are finished, stop the containers with `Ctrl+C` and run:
    ```bash

--- a/films/server.js
+++ b/films/server.js
@@ -125,6 +125,18 @@ app.put('/api/v1/films/:id', verifyToken, async (req, res) => {
   }
 });
 
+app.delete('/api/v1/films/:id', verifyToken, async (req, res) => {
+  try {
+    const film = await Film.findOneAndDelete({ _id: req.params.id, user: req.user.username });
+    if (!film) {
+      return res.status(404).json({ message: 'Film not found' });
+    }
+    res.json({ message: 'Film deleted successfully' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
 app.post('/api/v1/register', async (req, res) => {
   const { name, username, password } = req.body;
   if (!name || !username || !password) {


### PR DESCRIPTION
## Summary
- allow authenticated users to delete individual films by id
- document DELETE /api/v1/films/:id endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd films && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af7eb92d4083259182d550b578d0fe