### PR TITLE
Fix mobile API usage and patch Android build

### DIFF
--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -7,6 +7,7 @@ import { handleResponse } from '../lib/api';
 export default function Register() {
   const router = useRouter();
   const { apiBase } = useContext(AuthContext);
+  const [name, setName] = useState('');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
 
@@ -14,7 +15,7 @@ export default function Register() {
     try {
       const res = await fetch(`${apiBase}/register`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password }),
+        body: JSON.stringify({ name, username, password }),
       });
       await handleResponse(res);
       Alert.alert('Success', 'Account created');
@@ -27,6 +28,7 @@ export default function Register() {
   return (
     <View style={styles.wrap}>
       <Text style={styles.h1}>Register</Text>
+      <TextInput placeholder="Name" value={name} onChangeText={setName} style={styles.input} />
       <TextInput placeholder="Username" value={username} onChangeText={setUsername} autoCapitalize="none" style={styles.input} />
       <TextInput placeholder="Password" value={password} onChangeText={setPassword} secureTextEntry style={styles.input} />
       <Button title="Create Account" onPress={submit} />

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -20,6 +20,10 @@ export default function FilmsScreen() {
     try {
       const headers = token ? { Authorization: `Bearer ${token}` } : {};
       const res = await fetch(`${apiBase}/films`, { headers });
+      if (res.status === 404) {
+        setFilms([]);
+        return;
+      }
       const data = await handleResponse(res);
       setFilms(Array.isArray(data) ? data : []);
     } catch (err: any) {

--- a/mobile/patches/@react-native+gradle-plugin+0.73.4.patch
+++ b/mobile/patches/@react-native+gradle-plugin+0.73.4.patch
@@ -1,0 +1,27 @@
+diff --git a/node_modules/@react-native/gradle-plugin/build.gradle.kts b/node_modules/@react-native/gradle-plugin/build.gradle.kts
+index 9346508..697732c 100644
+--- a/node_modules/@react-native/gradle-plugin/build.gradle.kts
++++ b/node_modules/@react-native/gradle-plugin/build.gradle.kts
+@@ -7,7 +7,6 @@
+ 
+ import org.gradle.api.internal.classpath.ModuleRegistry
+ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+-import org.gradle.configurationcache.extensions.serviceOf
+ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+ 
+ plugins {
+@@ -49,13 +48,7 @@ dependencies {
+ 
+   testImplementation(libs.junit)
+ 
+-  testRuntimeOnly(
+-      files(
+-          serviceOf<ModuleRegistry>()
+-              .getModule("gradle-tooling-api-builders")
+-              .classpath
+-              .asFiles
+-              .first()))
++  // Removed serviceOf usage for compatibility
+ }
+ 
+ // We intentionally don't build for Java 17 as users will see a cryptic bytecode version


### PR DESCRIPTION
## Summary
- handle empty film list responses gracefully
- include name when creating accounts
- patch React Native gradle plugin to avoid missing serviceOf

## Testing
- `npm --prefix mobile test` (fails: Missing script "test")
- `npx --prefix mobile --no-install tsc --noEmit` (fails: missing packages)


------
https://chatgpt.com/codex/tasks/task_e_68afcc312f848325b0d05474064685c5